### PR TITLE
Fixing bug with location refresh

### DIFF
--- a/lib/screens/location_screen.dart
+++ b/lib/screens/location_screen.dart
@@ -68,7 +68,9 @@ class _LocationScreenState extends State<LocationScreen> {
                   FlatButton(
                     onPressed: () async {
                       var weatherData = await weather.getLocationWeather();
-                      updateUI(weatherData);
+                      setState(() {
+                        updateUI(weatherData);
+                      });
                     },
                     child: Icon(
                       Icons.near_me,


### PR DESCRIPTION
Fixes bug when you change location via an emulator and click on update location. But the app does not reflect the changes. This is due to setState missing.

Tested on android emulator.