### PR TITLE
Added internet permissions for Android in AndroidManifest.xml file.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="co.appbrewery.clima">
-
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that


### PR DESCRIPTION
According to the [Networking](https://flutter.dev/docs/development/data-and-backend/networking) section of original Flutter documentation, it has been clearly mentioned that `<uses-permission android:name="android.permission.INTERNET" />` has to be added to the AndroidManifest.xml file so as to use the internet to fetch location data in an Android device. 
* Only applicable to Android platform; iOS doesn't require such additional step. 

I think that might be the real reason why many students are not being able to test the release app of Clima on their Android device.