### PR TITLE
Upgrading pre 1.12 Android project

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="clima"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -32,4 +31,7 @@
             </intent-filter>
         </activity>
     </application>
+    <meta-data
+        android:name="flutterEmbedding"
+        android:value="2" />
 </manifest>

--- a/android/app/src/main/java/co/appbrewery/clima/MainActivity.java
+++ b/android/app/src/main/java/co/appbrewery/clima/MainActivity.java
@@ -1,13 +1,6 @@
 package co.appbrewery.clima;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
 }


### PR DESCRIPTION
In order to better support the execution environments of adding Flutter to an existing project, the old Android platform-side wrappers hosting the Flutter runtime at io.flutter.app.FlutterActivity and their associated classes are now deprecated. New wrappers at io.flutter.embedding.android.FlutterActivity and associated classes now replace them.