### PR TITLE
Update networking.dart

### DIFF
--- a/lib/services/networking.dart
+++ b/lib/services/networking.dart
@@ -4,7 +4,12 @@ import 'dart:convert';
 class NetworkHelper {
   NetworkHelper(this.url);
 
-  final String url;
+  final url = new Uri.https(
+        "samples.openweathermap.org", "/data/2.5/weather", {
+      "lat": "35",
+      "lon": "139",
+      "appid": "439d4b804bc8187953eb36d2a8c26a02"
+    });
 
   Future getData() async {
     http.Response response = await http.get(url);


### PR DESCRIPTION
The http.get of the new http library doesnt support url as an input but it asks for Uri object.